### PR TITLE
feature group selection button

### DIFF
--- a/networkgen/static/js/networkgen.js
+++ b/networkgen/static/js/networkgen.js
@@ -62,6 +62,7 @@ function draw() {
    // MANIPULATION
    manipulation: {
     addNode : false,
+    editEdge : false,
     addEdge: function (data, callback) {
      console.log('add edge', data);
      // empty if statement removes add edge to self funtionality.
@@ -75,8 +76,9 @@ function draw() {
      }
     }
   },
-  "interaction": {
+  interaction: {
    hover: true,
+   multiselect: true
   }
  };
 
@@ -108,6 +110,32 @@ function draw() {
 //   clearPopUp();
 //   callback(data);
 // }
+// SAVE SELECTION BUTTON
+// saves a group of node IDs to a variable. Can be used downstream to look at statistics for the selected group.
+function saveselection(){
+
+  const selNodes = network.getSelectedNodes()
+
+  if (selNodes.length == 0){
+    // catch cases where user has not selected nodes.
+    alert("Please select ligands to save to group.")
+  } else {
+  // require user to insert group name. Repop when no text input. :
+  do{
+    // prompt with string field
+    var groupName = prompt("Enter an identifier for this group, then press OK. Press Cancel\n\
+if you do not want to make a group with molecule(s):\n"+selNodes+".");
+} while(groupName !== null && groupName === "") // the while statement makes the prompt reappear
+// when no string is input.
+
+// if user has provided a name for the group, save the group name and node IDs.
+if (groupName !== null) {
+  console.log(groupName, selNodes)
+  // HERE PROCESS groupName AND selNodes TO NEXT STEP IN WORKFLOW
+  // TODO
+  }}
+
+}
 
 // FINISH BUTTON/
 // reduced version of https://stackoverflow.com/questions/40489700/visjs-save-manipulated-data-to-json
@@ -125,11 +153,6 @@ You can find a list of edges here (hlink).");
   // HERE PROCESS writedata TO NEXT STEP IN WORKFLOW
   // TODO
 };
-
-
-// document.getElementById('extract-positions').addEventListener('click', e => {
-  
-
  
 
 
@@ -319,6 +342,7 @@ function redo(){
 $(document).ready(function() {
               // apply css
   css_for_manipulation();
+  $("#save-sele").on("click", saveselection);
   $("#btn-undo").on("click", undo);
   $("#btn-redo").on("click", redo);
   $("#extract-positions").on("click", savegraph)

--- a/networkgen/templates/networkgen/index.html
+++ b/networkgen/templates/networkgen/index.html
@@ -25,6 +25,8 @@
  <div id="network-btns">
   <button id="btn-undo" type="button" class="btn btn-light"><i class="fas fa-arrow-left "></i></button>
   <button id="btn-redo" type="button" class="btn btn-light"><i class="fas fa-arrow-right "></i></button>
+  <button id="save-sele" type="button" class="btn btn-light">Save Group
+  </button>
   <button id="extract-positions" type="button" class="btn btn-light">Finish
   </button>
  </div>


### PR DESCRIPTION
implemented a "Save Group" and enabled `multiselect : true` in visjs code such that now:
- you can select multiple nodes by either long-clicking or CMD+click or Ctrl+click (Mac/ non-Mac, resp.)
- with 1 or more nodes selected, clicking "Save Group" button:
  * prompts user with message and box to input group name 
  * if user clicks OK without inputting a string the prompt reappears (will disappear when clicking Cancel)
  * if user clicks OK with a string for group name, saves the list of selected node IDs as well as the group name to variable (to be handled by Q later as with PR #3
- if "Save Group" button is clicked without selecting any nodes, alert the user that nodes have to selected first 

Bonus: fixed bug that @esguerra ran into that while editing an edge connectivity you can connect the edge to its own starting node. Disabled`editEdge` to handle this -> we don't want the user to be able to move edges across the network anyway because in this way edge information (such as ddG) is also transferred across the network.